### PR TITLE
fix paths for /fonts dir

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,7 @@ gulp.task('sass', function(){
  ******************************************************************************/
 gulp.task('fonts', function() {
   return gulp.src(path.join(config.paths.ionicDir, config.paths.ionicFontFiles))
-         .pipe(gulp.dest(path.join(config.paths.buildDir, config.paths.buildFontsDir)));
+    .pipe(gulp.dest(path.join(config.paths.wwwDir, config.paths.buildDir, config.paths.buildFontsDir)));
 });
 
 


### PR DESCRIPTION
The `fonts` directory was being generated at the root of the project, rather than in the `www/build` folder. This made icons work for me again, so I think this makes sense.

Let me know if you were thinking something else.
