### PR TITLE
Allow import from app directory.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,9 @@ module.exports = {
     ]
   },
   resolve: {
+    root: [
+      'app'
+    ],
     alias: {
       'ionic': 'ionic-framework',
       'web-animations.min': path.normalize('ionic-framework/js/web-animations.min')


### PR DESCRIPTION
Allow import from app directory.

```
import {MyService from '../../../../service';    // Not so good.
import {MyService} from 'service';    // More readable.
```

Assuming service.ts is `app/service.ts`.
