### PR TITLE
chore(gulp): end clean task with return

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,5 +44,5 @@ gulp.task('html', ['clean'], copyHTML);
 gulp.task('fonts', ['clean'], copyFonts);
 gulp.task('scripts', ['clean'], copyScripts);
 gulp.task('clean', function(done){
-  del('www/build', done);
+  return del('www/build', done);
 });


### PR DESCRIPTION
Without a return statement the following tasks are broken.
- sass
- html
- fonts
- scripts
