### PR TITLE
chore(scripts-copy): update to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ionic-gulp-fonts-copy": "^1.0.0",
     "ionic-gulp-html-copy": "^1.0.0",
     "ionic-gulp-sass-build": "^1.0.0",
-    "ionic-gulp-scripts-copy": "^1.0.0",
+    "ionic-gulp-scripts-copy": "^1.0.1",
     "run-sequence": "1.1.5"
   }
 }


### PR DESCRIPTION
I guess that this might be necessary because of the fix to load `es6-shim` before `angular2-polyfills`, i.e. the following commit: https://github.com/driftyco/ionic2-starter-blank/commit/76a452ccae124438094c4c42706bac364dc44a3e.
