### PR TITLE
Disable the source-map bundling for release builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,8 @@ var copyHTML = require('ionic-gulp-html-copy');
 var copyFonts = require('ionic-gulp-fonts-copy');
 var copyScripts = require('ionic-gulp-scripts-copy');
 
+var isRelease = argv.indexOf('--release') > -1;
+
 gulp.task('watch', ['clean'], function(done){
   runSequence(
     ['sass', 'html', 'fonts', 'scripts'],
@@ -48,10 +50,15 @@ gulp.task('build', ['clean'], function(done){
   runSequence(
     ['sass', 'html', 'fonts', 'scripts'],
     function(){
-      buildBrowserify().on('end', done);
+      buildBrowserify({
+        browserifyOptions: {
+          debug: !isRelease
+        }
+      }).on('end', done);
     }
   );
 });
+
 gulp.task('sass', buildSass);
 gulp.task('html', copyHTML);
 gulp.task('fonts', copyFonts);


### PR DESCRIPTION
Excludes the source-map from the build when building the project with a `--release` flag.
