### PR TITLE
chore enable es6-promises in gulp (for node 0.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ $RECYCLE.BIN/
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+
+# VS TACO
+.vs/
+bin/
+bld/
+*.user
+*.suo

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+var Promise = require("es6-promise").Promise;
 var gulp = require('gulp'),
     gulpWatch = require('gulp-watch'),
     del = require('del'),

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ionic-gulp-html-copy": "^1.0.0",
     "ionic-gulp-sass-build": "^1.0.0",
     "ionic-gulp-scripts-copy": "^1.0.1",
-    "run-sequence": "1.1.5"
+    "run-sequence": "1.1.5",
+    "es6-promise" : "^3.1.2"
   }
 }


### PR DESCRIPTION
VS 2015 uses Node 0.10.35 which is not ES6 compatible. To fix this issue add es6-promises 
