### PR TITLE
Set "typescript" to true for a TypeScript project.

### DIFF
--- a/ionic.config.json
+++ b/ionic.config.json
@@ -1,5 +1,6 @@
 {
   "name": "ionic2-app-base",
   "app_id": "",
+  "typescript": true,
   "v2": true
 }


### PR DESCRIPTION
I'm not sure why it's missing, but I guess that it should be present for a TypeScript project.
