### PR TITLE
Lock "rxjs" dependency to "5.0.0-beta.6"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ionic-native": "^1.1.0",
     "ionicons": "3.0.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Should be the same as in:

https://github.com/driftyco/ionic/blob/2.0/package.json#L32
https://github.com/angular/angular/blob/master/package.json#L23
