### PR TITLE
Lock "rxjs" dependency to "5.0.0-beta.6" - typescript branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ionic-native": "^1.1.0",
     "ionicons": "3.0.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/driftyco/ionic2-app-base/pull/32
