### PR TITLE
Build before uploading

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ gulp.task('serve:before', ['watch']);
 gulp.task('emulate:before', ['build']);
 gulp.task('deploy:before', ['build']);
 gulp.task('build:before', ['build']);
+gulp.task('upload:before', ['build']);
 
 // we want to 'watch' when livereloading
 var shouldWatch = argv.indexOf('-l') > -1 || argv.indexOf('--livereload') > -1;


### PR DESCRIPTION
If you run `ionic upload` without building first (either directly or indirectly), you may be surprised to learn that changes since you last built are not uploaded. The CLI warns:

```
WARN: No 'upload:before' gulp task found!
If your app requires a build step, you may want to ensure it runs before upload.
```

I think the starter app's gulpfile should build before upload.
