### PR TITLE
fix(): Add peer dependencies of ionic-angular as dependencies of app-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@angular/common": "^2.0.0",
     "@angular/compiler": "^2.0.0",
+    "@angular/compiler-cli": "^0.6.2",
     "@angular/core": "^2.0.0",
     "@angular/forms": "^2.0.0",
     "@angular/http": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,20 @@
     "run:before": "build"
   },
   "dependencies": {
+    "@angular/common": "^2.0.0",
+    "@angular/compiler": "^2.0.0",
+    "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0",
+    "@angular/http": "^2.0.0",
+    "@angular/platform-browser": "^2.0.0",
+    "@angular/platform-browser-dynamic": "^2.0.0",
+    "@angular/platform-server": "^2.0.0",
     "ionic-angular": "^2.0.0-rc.0",
     "ionicons" : "^3.0.0",
     "@ionic/storage": "^1.0.3",
-    "ionic-native": "^2.0.3"
+    "ionic-native": "^2.0.3",
+    "rxjs": "^5.0.0-beta.12",
+    "zone.js": "^0.6.21"
   },
   "devDependencies": {
     "@ionic/app-scripts": "latest",


### PR DESCRIPTION
This resolves issues that have resulted from users of npm2 trying to create a new project with ionic2.
