### PR TITLE
Solved splashscreen not displaying on starter projects issue

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -28,7 +28,6 @@
       Change these to configure how the splashscreen displays and fades in/out.
       More info here: https://github.com/apache/cordova-plugin-splashscreen
     -->
-    <preference name="SplashScreenDelay" value="0"/>
     <preference name="FadeSplashScreen" value="false"/>
     <preference name="FadeSplashScreenDuration" value="0"/>
     <preference name="SplashScreenBackgroundColor" value="0xFFFFFFFF" />


### PR DESCRIPTION
Starter projects are currently not displaying splashscreen due to SplashScreenDelay configuration in config.xml.

Removing that tag shows the splashscreen correctly. 
