### PR TITLE
Keep the www folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ plugins/
 plugins/android.json
 plugins/ios.json
 www/
+!www/.gitkeep
 $RECYCLE.BIN/
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ platforms/
 plugins/
 plugins/android.json
 plugins/ios.json
-www/
+www/*
 !www/.gitkeep
 $RECYCLE.BIN/
 


### PR DESCRIPTION
This error shows up if the `www` folder does not exist.

```shell
Error: Current working directory is not a Cordova-based project.
```
after running:
```shell
$ cordova platform add browser
```