### PR TITLE
fix(splash): On Android resume show splash screen

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -30,6 +30,7 @@
     -->
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />
+    <preference name="SplashShowOnlyFirstTime" value="false" />
     <feature name="StatusBar">
         <param name="ios-package" onload="true" value="CDVStatusBar" />
     </feature>


### PR DESCRIPTION
Override the default behaviour on Android. Show the splash screen even when the app has been closed with the back button. 

For more information: https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/#android-quirks