### PR TITLE
docs(service-worker): fix sw-toolbox doc link

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,5 +1,5 @@
 /**
- * Check out https://googlechrome.github.io/sw-toolbox/docs/master/index.html for
+ * Check out https://googlechrome.github.io/sw-toolbox/#main for
  * more info on how to use sw-toolbox to custom configure your service worker.
  */
 


### PR DESCRIPTION
#### Short description of what this resolves:

A broken link to the sw-docs

#### Changes proposed in this pull request:

- Change the link in the comments to the correct link

**Ionic Version**: 2.x / 3.x

It's kind of dumb and small but I hope it helps future 'me's to find what they need faster
