### PR TITLE
fix(): remove statusbar settings from root config

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -32,9 +32,6 @@
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />
     <preference name="SplashShowOnlyFirstTime" value="false" />
-    <feature name="StatusBar">
-        <param name="ios-package" onload="true" value="CDVStatusBar" />
-    </feature>
 
     <plugin name="ionic-plugin-keyboard" spec="~2.2.1"/>
     <plugin name="cordova-plugin-whitelist" spec="1.3.1"/>


### PR DESCRIPTION
This gets added at build time to iOS, so is not needed at the root.