### PR TITLE
fix(config.xml): update cordova-plugin-statusbar to 2.2.2

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -39,7 +39,7 @@
     <plugin name="ionic-plugin-keyboard" spec="~2.2.1"/>
     <plugin name="cordova-plugin-whitelist" spec="1.3.1"/>
     <plugin name="cordova-plugin-console" spec="1.0.5"/>
-    <plugin name="cordova-plugin-statusbar" spec="2.2.1"/>
+    <plugin name="cordova-plugin-statusbar" spec="2.2.2"/>
     <plugin name="cordova-plugin-device" spec="1.1.4"/>
     <plugin name="cordova-plugin-splashscreen" spec="~4.0.1"/>
 </widget>


### PR DESCRIPTION
The current version of cordova-plugin-statusbar has issues with some plugins. After returning from a plugin the screen may be white in landscape mode. See also: https://issues.apache.org/jira/browse/CB-12141