### PR TITLE
fix(Splash): White screen after splash screen

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -21,7 +21,6 @@
   <preference name="AutoHideSplashScreen" value="false"/>
   <preference name="FadeSplashScreenDuration" value="800"/>
   <preference name="SplashMaintainAspectRatio" value="true"/>
-  <preference name="FadeSplashScreenDuration" value="10000"/>
 
   <!--
     Change these to configure how the splashscreen displays and fades in/out.
@@ -29,7 +28,7 @@
   -->
   <preference name="SplashShowOnlyFirstTime" value="false"/>
   <preference name="SplashScreen" value="screen"/>
-  <preference name="SplashScreenDelay" value="3000"/>
+  <preference name="SplashScreenDelay" value="10000"/>
 
   <platform name="android">
     <allow-intent href="market:*"/>

--- a/config.xml
+++ b/config.xml
@@ -19,9 +19,9 @@
   <preference name="android-minSdkVersion" value="16"/>
   <preference name="BackupWebStorage" value="none"/>
   <preference name="AutoHideSplashScreen" value="false"/>
-  <preference name="FadeSplashScreenDuration" value="1000"/>
+  <preference name="FadeSplashScreenDuration" value="800"/>
   <preference name="SplashMaintainAspectRatio" value="true"/>
-  <preference name="FadeSplashScreenDuration" value="5000"/>
+  <preference name="FadeSplashScreenDuration" value="10000"/>
 
   <!--
     Change these to configure how the splashscreen displays and fades in/out.

--- a/config.xml
+++ b/config.xml
@@ -18,8 +18,10 @@
   <preference name="DisallowOverscroll" value="true"/>
   <preference name="android-minSdkVersion" value="16"/>
   <preference name="BackupWebStorage" value="none"/>
+  <preference name="AutoHideSplashScreen" value="false"/>
+  <preference name="FadeSplashScreenDuration" value="1000"/>
   <preference name="SplashMaintainAspectRatio" value="true"/>
-  <preference name="FadeSplashScreenDuration" value="300"/>
+  <preference name="FadeSplashScreenDuration" value="5000"/>
 
   <!--
     Change these to configure how the splashscreen displays and fades in/out.


### PR DESCRIPTION
This problem is not new. Many users have and had a problem with the splashscreen and just white screen after the app starts.

There are two problems.

1. The Splash screen delay is too short so the splash screen.hide() method in the app.component.ts file is useless. The app won't start in just 300ms! 
2. Because the fade animation is a bit too fast, the will still be a short white screen.


My workaround for this problem is to set the delay to a high-value like 10.000ms and disable the autohide value. I also increased the fade out duration to 1000ms.

Let me know your thoughts about this change. maybe there is a better solution but we should increase the delay value.

Related posts: 
https://forum.ionicframework.com/t/after-splash-screen-display-white-screen-long-time/80162
https://forum.ionicframework.com/t/ionic-2-startup-too-slow/78591/11