### PR TITLE
fix(splash screen): white screen after start

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -20,6 +20,7 @@
     <preference name="BackupWebStorage" value="none"/>
     <preference name="SplashMaintainAspectRatio" value="true"/>
     <preference name="FadeSplashScreenDuration" value="300"/>
+    <preference name="AutoHideSplashScreen" value="false"/>
 
     <!--
       Change these to configure how the splashscreen displays and fades in/out.
@@ -27,7 +28,7 @@
     -->
     <preference name="SplashShowOnlyFirstTime" value="false"/>
     <preference name="SplashScreen" value="screen"/>
-    <preference name="SplashScreenDelay" value="3000"/>
+    <preference name="SplashScreenDelay" value="10000"/>
 
     <platform name="android">
         <allow-intent href="market:*"/>


### PR DESCRIPTION
This problem is not new. Many users have/had a problem with a white screen after the app starts.

There are two problems.

1. The Splash screen delay is too short so the splash screen.hide() method in the app.component.ts file is useless. The app won't start in just 3000ms if the app itself is big (no lazy loading).
2. Because the fade animation is a bit too fast there will still be a short white screen.

My workaround for this problem is to set the delay to a high-value like 10.000ms and set the autohide value to false (default, if not set, is true).

Let me know your thoughts about this change. maybe there is a better solution but we should increase the delay value.

Related posts:
https://forum.ionicframework.com/t/after-splash-screen-display-white-screen-long-time/80162
https://forum.ionicframework.com/t/ionic-2-startup-too-slow/78591/11
https://forum.ionicframework.com/t/splash-screen-delay/78186/14