### PR TITLE
chore(package): update rxjs to 5.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ionic/storage": "2.0.1",
     "ionic-angular": "3.6.0",
     "ionicons": "3.0.0",
-    "rxjs": "5.4.0",
+    "rxjs": "5.4.3",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.12"
   },


### PR DESCRIPTION
This PR updates rxjs to v5.4.3 which contains fixes to allow compilation under TypeScript 2.4.  
See https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md for more information.
Crossref to https://github.com/ionic-team/ionic-native/pull/1799