### PR TITLE
chore(service-worker): change caching strategy to fastest

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,5 +1,5 @@
 /**
- * Check out https://googlechrome.github.io/sw-toolbox/ for
+ * Check out https://googlechromelabs.github.io/sw-toolbox/ for
  * more info on how to use sw-toolbox to custom configure your service worker.
  */
 
@@ -24,7 +24,7 @@ self.toolbox.precache(
 );
 
 // dynamically cache any other local assets
-self.toolbox.router.any('/*', self.toolbox.cacheFirst);
+self.toolbox.router.any('/*', self.toolbox.fastest);
 
 // for any other requests go to the network, cache,
 // and then only use that cached resource if your user goes offline


### PR DESCRIPTION
@jgw96 People (including me) are confused about their PWA not being updated when they deploy a new version. 

See:
* https://forum.ionicframework.com/t/pwa-service-worker-and-providing-update/94025
* https://forum.ionicframework.com/t/how-to-update-app-when-its-cached-by-a-service-worker/107054
* https://forum.ionicframework.com/t/ionic-pwa-not-updating-new-content/94405
* https://forum.ionicframework.com/t/pwa-how-does-the-service-worker-know-when-i-deploy-new-files/75961

I suggest changing the default caching strategy to fastest, which does the following:

> [toolbox.fastest](https://googlechromelabs.github.io/sw-toolbox/api.html#toolboxfastest)
Request the resource from both the cache and the network in parallel. Respond with whichever returns first. Usually this will be the cached version, if there is one. On the one hand this strategy will always make a network request, even if the resource is cached. On the other hand, if/when the network request completes the cache is updated, so that future cache reads will be more up-to-date.
